### PR TITLE
Add `process.versions.nbin` to binaries

### DIFF
--- a/example/src/hello.js
+++ b/example/src/hello.js
@@ -3,3 +3,6 @@ console.log("Hey there!");
 console.log("here is a banana");
 
 console.log("frogger");
+
+console.log("built with nbin", process.versions.nbin);
+

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 	"version": "1.1.2",
 	"description": "Fast and robust node.js binary compiler.",
 	"main": "out/api.js",
-	"scripts": {	
-		"test": "node node_modules/.bin/jest"	
+	"scripts": {
+		"test": "node node_modules/.bin/jest"
 	},
 	"typings": "typings/nbin.d.ts",
 	"author": "Coder",

--- a/src/patches/thirdPartyMain.ts
+++ b/src/patches/thirdPartyMain.ts
@@ -8,6 +8,12 @@
 import * as nbin from "nbin";
 
 /**
+ * Specify the version of nbin this binary was built with. This is
+ * automatically replaced by webpack.
+ */
+process.versions.nbin = '<NBIN_VERSION>';
+
+/**
  * If bypassing nbin don't touch a thing.
  */
 if (!process.env.NBIN_BYPASS) {
@@ -15,3 +21,4 @@ if (!process.env.NBIN_BYPASS) {
 		process.argv.splice(1, 0, nbin.mainFile);
 	}
 }
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const HappyPack = require("happypack");
 const webpack = require("webpack");
 
 const root = path.resolve(__dirname);
+const pkg = require("./package.json");
 
 const baseConfig = {
 	context: root,
@@ -12,9 +13,16 @@ const baseConfig = {
 	target: "node",
 	module: {
 		rules: [{
-			use: [{
-				loader: "happypack/loader?id=ts",
-			}],
+			use: [
+				{
+					loader: "string-replace-loader",
+					options: {
+						search: "<NBIN_VERSION>",
+						replace: pkg.version,
+					},
+				},
+				"happypack/loader?id=ts",
+			],
 			test: /(^.?|\.[^d]|[^.]d|[^.][^d])\.tsx?$/,
 		}, {
 			use: [{


### PR DESCRIPTION
This adds a line in `thirdPartyMain.js` that gets automatically replaced by webpack with the current version of the package from `package.json` on build. As `thirdPartyMain.js` gets injected into the node binaries, this will require the nbin node binaries to be rebuilt on our server.

I created this pull request to allow for checking if we're in an nbin environment without importing "nbin" (which won't work if you webpack your sources).

`DefinePlugin` wasn't working properly, so I used [string-replace-loader](https://github.com/Va1/string-replace-loader) instead to inject the version string. Using `<NBIN_VERSION>` anywhere in the webpacked source files will be replaced with the current version from `package.json`.