### PR TITLE
Fix docker_build script to use exec format from Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg)](#)
 [![Discord](https://discordapp.com/api/guilds/463752820026376202/widget.png)](https://discord.gg/zxSwN8Z)
 
-Fast and robust node.js binary compiler.
-
-**WARNING:** This project was created for [code-server](https://github.com/cdr/code-server) and may provide limited support.
-
-Why was this made? Why not use `pkg` or `nexe`?
+nbin is a in-house binary compiler made initially for code-server but can be used by other projects as well. Unlike contemporaries like `nbin` and `nexe` we support the following that is normally not supported by them:
 
 - Support for native node modules.
 - No magic. The user specifies all customization. An example of this is overriding the filesystem.
@@ -40,7 +36,7 @@ const output = bin.bundle();
 
 ### Forks
 
-`child_process`.`fork` works as expected. `nbin` will treat the compiled binary as the original node binary when the `process.send` function is available.
+`child_process.fork()` works as expected. `nbin` will treat the compiled binary as the original node binary when the `process.send()` function is available.
 
 ### Webpack
 
@@ -66,4 +62,4 @@ You can pass [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#cli_node_options_o
 NODE_OPTIONS="--inspect-brk" ./path/to/bin
 ```
 
-Gzip'd JavaScript files are supported to reduce bundle size.
+We also support compressed JavaScript to reduce your bundle's size, preferrably gzip.


### PR DESCRIPTION
Apparently the way I originally wrote this was the same as dockerfiles were and that caused issues as raised by @deansheather. I think I figured out a way to run commands on the ARM images by wrapping the `exec` function's arguments with `cross-build-start` and `cross-build-end` which is fundamentally the same.

This is highly untested at the moment, so it needs further testing.