### PR TITLE
[centos] add -C flag for install

### DIFF
--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,9 +1,9 @@
 FROM centos:7
 
-RUN yum install -y centos-release-scl
+RUN yum install -y centos-release-scl -C
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN yum install -y devtoolset-6
-RUN yum install -y gcc-c++
+RUN yum install -y devtoolset-6 -C
+RUN yum install -y gcc-c++ -C
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm
 
 RUN mkdir /root/node


### PR DESCRIPTION
this prevents updating gcc which should fix cdr/code-server#209

See: https://unix.stackexchange.com/questions/74449/yum-install-package-without-updating-other-packages-or-fail