### PR TITLE
ARM Targeting support + Move to GitHub Actions

### DIFF
--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Setup Builder instance
         run: |
             export DOCKER_CLI_EXPERMIENTAL=enabled
+            export DOCKER_BUILDKIT=1
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
@@ -24,12 +25,14 @@ jobs:
       - name: Build Images - ARM (CentOS)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
+           export DOCKER_BUILDKIT=1
            docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile
            docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile
       
       - name: Build Images - ARM (Alpine)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
+           export DOCKER_BUILDKIT=1
            docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile
            docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile
 
@@ -40,6 +43,13 @@ jobs:
 
       - name: Install Docker Edge Build (for Xbuild runs)
         run: wget -qO - https://test.docker.com | sh
+
+      - name: Install buildx
+        run: |
+          mkdir -p  $HOME/.docker/cli-plugins/
+          touch $HOME/.docker/cli-plugins/docker-buildx
+          wget -qO - https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 > $HOME/.docker/cli-plugins/docker-buildx
+          chmod a+x $HOME/.docker/cli-plugins/docker-buildx
       
       - name: Setup Builder instance
         run: |

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -24,21 +24,21 @@ jobs:
       - name: Setup Builder instance
         run: |
             export DOCKER_CLI_EXPERMIENTAL=enabled
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       
       - name: Build Images - ARM (CentOS)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           export DOCKER_BUILDKIT=1
            docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
            docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
       
       - name: Build Images - ARM (Alpine)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           export DOCKER_BUILDKIT=1
            docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile .
            docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile .
 
@@ -60,6 +60,7 @@ jobs:
       - name: Setup Builder instance
         run: |
             export DOCKER_CLI_EXPERMIENTAL=enabled
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -33,22 +33,22 @@ jobs:
       - name: Build Images - ARM64
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm64 -t codercom/nbin-arm:arm64 -f arm.dockerfile .
+           docker buildx build --platform linux/arm64 -t codercom/nbin-arm64:latest -f arm.dockerfile .
 
       - name: Build Images - ARM
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm -t codercom/nbin-arm:arm -f arm.dockerfile .
+           docker buildx build --platform linux/arm -t codercom/nbin-arm:latest -f arm.dockerfile .
       
       - name: Build Images - ARM64 (Alpine)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile .
+           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine-arm64:latest -f alpine.dockerfile .
 
       - name: Build Images - ARM (Alpine)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile .
+           docker buildx build --platform linux/arm -t codercom/nbin-alpine-arm:latest -f alpine.dockerfile .
 
   build_amd64:
     runs-on: ubuntu-latest
@@ -76,9 +76,9 @@ jobs:
       - name: Build Images - AMD64 (CentOS)
         run: |
           export DOCKER_CLI_EXPERMIENTAL=enabled
-          docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile .
+          docker buildx build --platform linux/amd64 -t codercom/nbin-centos:latest -f centos.dockerfile .
       
       - name: Build Images - AMD64 (Alpine)
         run: |
          export DOCKER_CLI_EXPERMIENTAL=enabled
-         docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile .
+         docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:latest -f alpine.dockerfile .

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -14,10 +14,16 @@ jobs:
       - name: Install Docker Edge Build (for Xbuild runs)
         run: wget -qO - https://test.docker.com | sh
       
+      - name: Install buildx
+        run: |
+          mkdir -p  $HOME/.docker/cli-plugins/
+          touch $HOME/.docker/cli-plugins/docker-buildx
+          wget -qO - https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 > $HOME/.docker/cli-plugins/docker-buildx
+          chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+      
       - name: Setup Builder instance
         run: |
             export DOCKER_CLI_EXPERMIENTAL=enabled
-            export DOCKER_BUILDKIT=1
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -11,47 +11,47 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install Docker Edge Build (for Xbuild commands)
-        command: wget -qO - https://test.docker.com | sh
+      - name: Install Docker Edge Build (for Xbuild runs)
+        run: wget -qO - https://test.docker.com | sh
       
       - name: Setup Builder instance
-        command: |
+        run: |
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
       
       - name: Build Images - ARM (CentOS)
-        command: |
+        run: |
            docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile
            docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile
       
       - name: Build Images - ARM (Alpine)
-        command: |
+        run: |
            docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile
            docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile
 
       - name: Build Images - AMD64 (CentOS)
-        command: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
+        run: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
       
       - name: Build Images - AMD64 (Alpine)
-        command: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
+        run: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
 
   build_amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
 
-      - name: Install Docker Edge Build (for Xbuild commands)
-        command: wget -qO - https://test.docker.com | sh
+      - name: Install Docker Edge Build (for Xbuild runs)
+        run: wget -qO - https://test.docker.com | sh
       
       - name: Setup Builder instance
-        command: |
+        run: |
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
 
       - name: Build Images - AMD64 (CentOS)
-        command: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
+        run: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
       
       - name: Build Images - AMD64 (Alpine)
-        command: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
+        run: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -32,15 +32,15 @@ jobs:
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
            export DOCKER_BUILDKIT=1
-           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile
-           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile
+           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
+           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
       
       - name: Build Images - ARM (Alpine)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
            export DOCKER_BUILDKIT=1
-           docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile
-           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile
+           docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile .
+           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile .
 
   build_amd64:
     runs-on: ubuntu-latest
@@ -67,9 +67,9 @@ jobs:
       - name: Build Images - AMD64 (CentOS)
         run: |
           export DOCKER_CLI_EXPERMIENTAL=enabled
-          docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
+          docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile .
       
       - name: Build Images - AMD64 (Alpine)
         run: |
          export DOCKER_CLI_EXPERMIENTAL=enabled
-         docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
+         docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile .

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -29,16 +29,16 @@ jobs:
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      
-      - name: Build Images - ARM64 (CentOS)
-        run: |
-           export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
-
-      - name: Build Images - ARM (CentOS)
-        run: |
-           export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
+#  TODO: AArch64 support is broken for CentOS.            
+#      - name: Build Images - ARM64 (CentOS)
+#        run: |
+#           export DOCKER_CLI_EXPERMIENTAL=enabled
+#           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
+#  TODO: AArch64 support is broken for CentOS.
+#      - name: Build Images - ARM (CentOS)
+#        run: |
+#           export DOCKER_CLI_EXPERMIENTAL=enabled
+#           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
       
       - name: Build Images - ARM64 (Alpine)
         run: |

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -1,0 +1,57 @@
+name: Build Docker images
+on:
+  push:
+    branches:
+       - 'sr229/docker-xbuild'
+       - 'master'
+
+jobs:
+  build_arm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Docker Edge Build (for Xbuild commands)
+        command: wget -qO - https://test.docker.com | sh
+      
+      - name: Setup Builder instance
+        command: |
+            docker buildx create --name cdr-build
+            docker buildx use cdr-build
+            docker buildx inspect --bootstrap
+      
+      - name: Build Images - ARM (CentOS)
+        command: |
+           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile
+           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile
+      
+      - name: Build Images - ARM (Alpine)
+        command: |
+           docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile
+           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile
+
+      - name: Build Images - AMD64 (CentOS)
+        command: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
+      
+      - name: Build Images - AMD64 (Alpine)
+        command: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
+
+  build_amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Docker Edge Build (for Xbuild commands)
+        command: wget -qO - https://test.docker.com | sh
+      
+      - name: Setup Builder instance
+        command: |
+            docker buildx create --name cdr-build
+            docker buildx use cdr-build
+            docker buildx inspect --bootstrap
+
+      - name: Build Images - AMD64 (CentOS)
+        command: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
+      
+      - name: Build Images - AMD64 (Alpine)
+        command: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -30,17 +30,25 @@ jobs:
             docker buildx inspect --bootstrap
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       
+      - name: Build Images - ARM64 (CentOS)
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
+
       - name: Build Images - ARM (CentOS)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
            docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
-           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
       
+      - name: Build Images - ARM64 (Alpine)
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile .
+
       - name: Build Images - ARM (Alpine)
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
            docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile .
-           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile .
 
   build_amd64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -29,16 +29,16 @@ jobs:
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-#  TODO: AArch64 support is broken for CentOS.            
-#      - name: Build Images - ARM64 (CentOS)
-#        run: |
-#           export DOCKER_CLI_EXPERMIENTAL=enabled
-#           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
-#  TODO: AArch64 support is broken for CentOS.
-#      - name: Build Images - ARM (CentOS)
-#        run: |
-#           export DOCKER_CLI_EXPERMIENTAL=enabled
-#           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
+            
+      - name: Build Images - ARM64
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm64 -t codercom/nbin-arm:arm64 -f arm.dockerfile .
+
+      - name: Build Images - ARM
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm -t codercom/nbin-arm:arm -f arm.dockerfile .
       
       - name: Build Images - ARM64 (Alpine)
         run: |

--- a/.github/workflows/build-commit-docker.yml
+++ b/.github/workflows/build-commit-docker.yml
@@ -16,25 +16,22 @@ jobs:
       
       - name: Setup Builder instance
         run: |
+            export DOCKER_CLI_EXPERMIENTAL=enabled
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
       
       - name: Build Images - ARM (CentOS)
         run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
            docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile
            docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile
       
       - name: Build Images - ARM (Alpine)
         run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
            docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile
            docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile
-
-      - name: Build Images - AMD64 (CentOS)
-        run: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
-      
-      - name: Build Images - AMD64 (Alpine)
-        run: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
 
   build_amd64:
     runs-on: ubuntu-latest
@@ -46,12 +43,17 @@ jobs:
       
       - name: Setup Builder instance
         run: |
+            export DOCKER_CLI_EXPERMIENTAL=enabled
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
 
       - name: Build Images - AMD64 (CentOS)
-        run: docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
+        run: |
+          export DOCKER_CLI_EXPERMIENTAL=enabled
+          docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile
       
       - name: Build Images - AMD64 (Alpine)
-        run: docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile
+        run: |
+         export DOCKER_CLI_EXPERMIENTAL=enabled
+         docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -13,6 +13,14 @@ jobs:
 
       - name: Install Docker Edge Build (for Xbuild runs)
         run: wget -qO - https://test.docker.com | sh
+
+      
+      - name: Install buildx
+        run: |
+          mkdir -p  $HOME/.docker/cli-plugins/
+          touch $HOME/.docker/cli-plugins/docker-buildx
+          wget -qO - https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 > $HOME/.docker/cli-plugins/docker-buildx
+          chmod a+x $HOME/.docker/cli-plugins/docker-buildx
       
       - name: Setup Builder instance
         run: |

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -11,29 +11,29 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install Docker Edge Build (for Xbuild commands)
-        command: wget -qO - https://test.docker.com | sh
+      - name: Install Docker Edge Build (for Xbuild runs)
+        run: wget -qO - https://test.docker.com | sh
       
       - name: Setup Builder instance
-        command: |
+        run: |
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
       
       - name: Build Images - ARM (CentOS)
-        command: |
+        run: |
            docker buildx build --platform linux/arm -t cdr/nbin-centos:arm -f centos.dockerfile
            docker buildx build --platform linux/arm64 -t cdr/nbin-centos:arm64 -f centos.dockerfile
       
       - name: Build Images - ARM (Alpine)
-        command: |
+        run: |
            docker buildx build --platform linux/arm -t cdr/nbin-alpine:arm -f alpine.dockerfile
            docker buildx build --platform linux/arm64 -t cdr/nbin-alpine:arm64 -f alpine.dockerfile
 
       - name: Build Images - AMD64 (CentOS)
-        command: |
+        run: |
            docker buildx build --platform linux/amd64 -t cdr/nbin-centos:amd64 -f centos.dockerfile
       
       - name: Build Images - AMD64 (Alpine)
-        command: |
+        run: |
            docker buildx build --platform linux/amd64 -t cdr/nbin-alpine:amd64 -f alpine.dockerfile

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Setup Builder instance
         run: |
             export DOCKER_CLI_EXPERMIENTAL=enabled
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -1,0 +1,39 @@
+name: Build
+on:
+  push:
+    branches:
+       - 'sr229/docker-xbuild'
+       - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Docker Edge Build (for Xbuild commands)
+        command: wget -qO - https://test.docker.com | sh
+      
+      - name: Setup Builder instance
+        command: |
+            docker buildx create --name cdr-build
+            docker buildx use cdr-build
+            docker buildx inspect --bootstrap
+      
+      - name: Build Images - ARM (CentOS)
+        command: |
+           docker buildx build --platform linux/arm -t cdr/nbin-centos:arm -f centos.dockerfile
+           docker buildx build --platform linux/arm64 -t cdr/nbin-centos:arm64 -f centos.dockerfile
+      
+      - name: Build Images - ARM (Alpine)
+        command: |
+           docker buildx build --platform linux/arm -t cdr/nbin-alpine:arm -f alpine.dockerfile
+           docker buildx build --platform linux/arm64 -t cdr/nbin-alpine:arm64 -f alpine.dockerfile
+
+      - name: Build Images - AMD64 (CentOS)
+        command: |
+           docker buildx build --platform linux/amd64 -t cdr/nbin-centos:amd64 -f centos.dockerfile
+      
+      - name: Build Images - AMD64 (Alpine)
+        command: |
+           docker buildx build --platform linux/amd64 -t cdr/nbin-alpine:amd64 -f alpine.dockerfile

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -16,24 +16,8 @@ jobs:
       
       - name: Setup Builder instance
         run: |
+            export DOCKER_CLI_EXPERMIENTAL=enabled
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
-      
-      - name: Build Images - ARM (CentOS)
-        run: |
-           docker buildx build --platform linux/arm -t cdr/nbin-centos:arm -f centos.dockerfile
-           docker buildx build --platform linux/arm64 -t cdr/nbin-centos:arm64 -f centos.dockerfile
-      
-      - name: Build Images - ARM (Alpine)
-        run: |
-           docker buildx build --platform linux/arm -t cdr/nbin-alpine:arm -f alpine.dockerfile
-           docker buildx build --platform linux/arm64 -t cdr/nbin-alpine:arm64 -f alpine.dockerfile
-
-      - name: Build Images - AMD64 (CentOS)
-        run: |
-           docker buildx build --platform linux/amd64 -t cdr/nbin-centos:amd64 -f centos.dockerfile
-      
-      - name: Build Images - AMD64 (Alpine)
-        run: |
-           docker buildx build --platform linux/amd64 -t cdr/nbin-alpine:amd64 -f alpine.dockerfile
+          

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -29,4 +29,7 @@ jobs:
             docker buildx create --name cdr-build
             docker buildx use cdr-build
             docker buildx inspect --bootstrap
+      
+      - name: Build for ARM
+        run: scripts/ci.bash 
           

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: "Push to Registry"
         run: |
-          docker push codercom/nbin-arm:arm
-          docker push codercom/nbin-alpine:arm   
-          docker push codercom/nbin-arm:arm64
-          docker push codercom/nbin-alpine:arm64
+          docker push codercom/nbin-arm:latest
+          docker push codercom/nbin-alpine-arm:latest   
+          docker push codercom/nbin-arm64:latest
+          docker push codercom/nbin-alpine-arm64:latest
 
   build_amd64:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -27,15 +27,15 @@ jobs:
             docker buildx inspect --bootstrap
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       
-      - name: Build Images - ARM64 (CentOS)
+      - name: Build Images - ARM64
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
+           docker buildx build --platform linux/arm64 -t codercom/nbin-arm:arm64 -f arm.dockerfile .
 
-      - name: Build Images - ARM (CentOS)
+      - name: Build Images - ARM
         run: |
            export DOCKER_CLI_EXPERMIENTAL=enabled
-           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
+           docker buildx build --platform linux/arm -t codercom/nbin-arm:arm -f arm.dockerfile .
       
       - name: Build Images - ARM64 (Alpine)
         run: |
@@ -54,9 +54,9 @@ jobs:
 
       - name: "Push to Registry"
         run: |
-          docker push codercom/nbin-centos:arm
+          docker push codercom/nbin-arm:arm
           docker push codercom/nbin-alpine:arm   
-          docker push codercom/nbin-centos:arm64
+          docker push codercom/nbin-arm:arm64
           docker push codercom/nbin-alpine:arm64
 
   build_amd64:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,103 @@
+name: Build Docker images
+on:
+  - release
+
+jobs:
+  build_arm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Docker Edge Build (for Xbuild runs)
+        run: wget -qO - https://test.docker.com | sh
+      
+      - name: Install buildx
+        run: |
+          mkdir -p  $HOME/.docker/cli-plugins/
+          touch $HOME/.docker/cli-plugins/docker-buildx
+          wget -qO - https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 > $HOME/.docker/cli-plugins/docker-buildx
+          chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+      
+      - name: Setup Builder instance
+        run: |
+            export DOCKER_CLI_EXPERMIENTAL=enabled
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker buildx create --name cdr-build
+            docker buildx use cdr-build
+            docker buildx inspect --bootstrap
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      
+      - name: Build Images - ARM64 (CentOS)
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm64 -t codercom/nbin-centos:arm64 -f centos.dockerfile .
+
+      - name: Build Images - ARM (CentOS)
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm -t codercom/nbin-centos:arm -f centos.dockerfile .
+      
+      - name: Build Images - ARM64 (Alpine)
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm64 -t codercom/nbin-alpine:arm64 -f alpine.dockerfile .
+
+      - name: Build Images - ARM (Alpine)
+        run: |
+           export DOCKER_CLI_EXPERMIENTAL=enabled
+           docker buildx build --platform linux/arm -t codercom/nbin-alpine:arm -f alpine.dockerfile .
+
+      - uses: azure/docker-login@master
+        with:
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: "Push to Registry"
+        run: |
+          docker push codercom/nbin-centos:arm
+          docker push codercom/nbin-alpine:arm   
+          docker push codercom/nbin-centos:arm64
+          docker push codercom/nbin-alpine:arm64
+
+  build_amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Docker Edge Build (for Xbuild runs)
+        run: wget -qO - https://test.docker.com | sh
+
+      - name: Install buildx
+        run: |
+          mkdir -p  $HOME/.docker/cli-plugins/
+          touch $HOME/.docker/cli-plugins/docker-buildx
+          wget -qO - https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 > $HOME/.docker/cli-plugins/docker-buildx
+          chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+      
+      - name: Setup Builder instance
+        run: |
+            export DOCKER_CLI_EXPERMIENTAL=enabled
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker buildx create --name cdr-build
+            docker buildx use cdr-build
+            docker buildx inspect --bootstrap
+
+      - name: Build Images - AMD64 (CentOS)
+        run: |
+          export DOCKER_CLI_EXPERMIENTAL=enabled
+          docker buildx build --platform linux/amd64 -t codercom/nbin-centos:amd64 -f centos.dockerfile .
+      
+      - name: Build Images - AMD64 (Alpine)
+        run: |
+         export DOCKER_CLI_EXPERMIENTAL=enabled
+         docker buildx build --platform linux/amd64 -t codercom/nbin-alpine:amd64 -f alpine.dockerfile .
+      
+      - uses: azure/docker-login@master
+        with:
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: "Push to Registry"
+        run: |
+          docker push codercom/nbin-centos:amd64
+          docker push codercom/nbin-alpine:amd64        

--- a/aarch64-alpine.dockerfile
+++ b/aarch64-alpine.dockerfile
@@ -1,7 +1,0 @@
-FROM balenalib/aarch64-alpine-node:10.15-edge-build
-
-RUN ["cross-build-start"]
-
-RUN apk add --no-cache --no-progress bash gcc g++ ccache git make python linux-headers
-
-RUN ["cross-build-end"]

--- a/aarch64.dockerfile
+++ b/aarch64.dockerfile
@@ -1,7 +1,0 @@
-FROM balenalib/aarch64-debian-node:10.15-jessie-build
-
-RUN ["cross-build-start"]
-
-RUN apt-get update && apt-get -y install build-essential linux-headers-3.16.0-6-all-arm64 linux-headers-3.16.0-6-common gcc g++ ccache git make
-
-RUN ["cross-build-end"]

--- a/aarch64.dockerfile
+++ b/aarch64.dockerfile
@@ -2,6 +2,6 @@ FROM balenalib/aarch64-debian-node:10.15-jessie-build
 
 RUN ["cross-build-start"]
 
-RUN apt-get update && apt-get -y install build-essential linux-headers-generic gcc g++ ccache git make
+RUN apt-get update && apt-get -y install build-essential linux-headers-3.16.0-6-all-arm64 linux-headers-3.16.0-6-common gcc g++ ccache git make
 
 RUN ["cross-build-end"]

--- a/arm.dockerfile
+++ b/arm.dockerfile
@@ -1,0 +1,6 @@
+# Debian Target - only for ARM builds.
+# DO NOT USE THIS AS A TARGET FOR x86!
+FROM debian:8
+
+RUN apt update && \
+    apt install -y build-essential g++ gcc linux-headers-generic

--- a/arm.dockerfile
+++ b/arm.dockerfile
@@ -1,6 +1,6 @@
 # Debian Target - only for ARM builds.
 # DO NOT USE THIS AS A TARGET FOR x86!
-FROM debian:8
+FROM ubuntu:18.04
 
 RUN apt update && \
     apt install -y build-essential g++ gcc linux-headers-generic

--- a/armhf-alpine.dockerfile
+++ b/armhf-alpine.dockerfile
@@ -1,7 +1,0 @@
-FROM balenalib/armv7hf-alpine-node:10.15-edge-build
-
-RUN ["cross-build-start"]
-
-RUN apk add --no-cache --no-progress bash gcc g++ ccache git make python linux-headers
-
-RUN ["cross-build-end"] 

--- a/armhf.dockerfile
+++ b/armhf.dockerfile
@@ -2,6 +2,6 @@ FROM balenalib/armv7hf-debian-node:10.15-jessie-build
 
 RUN ["cross-build-start"]
 
-RUN apt-get update && apt-get -y install build-essential linux-headers-generic gcc g++ ccache git make
+RUN apt-get update && apt-get -y install build-essential linux-headers-3.16.0-9-all-armhf linux-headers-3.16.0-9-common gcc g++ ccache git make
 
 RUN ["cross-build-end"]

--- a/armhf.dockerfile
+++ b/armhf.dockerfile
@@ -1,7 +1,0 @@
-FROM balenalib/armv7hf-debian-node:10.15-jessie-build
-
-RUN ["cross-build-start"]
-
-RUN apt-get update && apt-get -y install build-essential linux-headers-3.16.0-9-all-armhf linux-headers-3.16.0-9-common gcc g++ ccache git make
-
-RUN ["cross-build-end"]

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y centos-release-scl
+RUN yum -y update && yum install -y centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum install -y devtoolset-6
 RUN yum install -y gcc-c++

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 
-RUN yum -y update && yum install -y centos-release-scl
+RUN yum install -y centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN yum install -y devtoolset-6
+RUN yum install -y devtoolset-7
 RUN yum install -y gcc-c++
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -18,15 +18,15 @@ function docker_build() {
 	 docker exec $containerID mkdir /src
 
 	 function exec() {
-	 	 docker exec $containerID bash -c "$@"
+         # HACK: cross-build-start and cross-build end is needed to be wrapped around commands.
+         # This is inevitably the only way to perform cross-targeting in-Docker.
+	 	 docker exec $containerID bash -c "cross-build-start; $@; cross-build-end"
 	 }
 
 	 docker cp ../. $containerID:/src
-	 exec "cross-build-start"
 	 exec "$PREBUILD_COMMAND/src/lib/node/build.sh"
 	 exec "cd /src && npm rebuild"
 	 exec "cd /src && npm test"
-	 exec "cross-build-end"
 	 docker cp $containerID:/src/lib/node/out/Release/node ../build/$PACKAGE_VERSION/$BINARY_NAME
 	 ;;
 	*)

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -12,15 +12,15 @@ source ./vars.sh
 # $BINARY_NAME
 function docker_build() {
 	case "$IMAGE" in
-	*armv7hf* | armv7hf | aarch64 | *aarch64*)
-	containerID=$(docker create -it -v $HOME/$CACHE_DIR:/ccache $IMAGE)
+	*arm | *arm64)
+	containerID=$(docker buildx create -it -v $HOME/$CACHE_DIR:/ccache $IMAGE)
+	# HACK: We can leverage the same VMs we use to make x86 builds but in expense of using QEMU
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker start $containerID
 	docker exec $containerID mkdir /src
 
 	function exec() {
-		# HACK: cross-build-start and cross-build end is needed to be wrapped around commands.
-		# This is inevitably the only way to perform cross-targeting in-Docker.
-		docker exec $containerID bash -c "cross-build-start; $@; cross-build-end"
+		docker exec $containerID bash -c "$@"
 	}
 
 		docker cp ../. $containerID:/src

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -13,38 +13,38 @@ source ./vars.sh
 function docker_build() {
 	case "$IMAGE" in
 	*armv7hf* | armv7hf | aarch64 | *aarch64*)
-	 containerID=$(docker create -it -v $HOME/$CACHE_DIR:/ccache $IMAGE)
-	 docker start $containerID
-	 docker exec $containerID mkdir /src
+	containerID=$(docker create -it -v $HOME/$CACHE_DIR:/ccache $IMAGE)
+	docker start $containerID
+	docker exec $containerID mkdir /src
 
-	 function exec() {
-         # HACK: cross-build-start and cross-build end is needed to be wrapped around commands.
-         # This is inevitably the only way to perform cross-targeting in-Docker.
-	 	 docker exec $containerID bash -c "cross-build-start; $@; cross-build-end"
-	 }
+	function exec() {
+		# HACK: cross-build-start and cross-build end is needed to be wrapped around commands.
+		# This is inevitably the only way to perform cross-targeting in-Docker.
+		docker exec $containerID bash -c "cross-build-start; $@; cross-build-end"
+	}
 
-	 docker cp ../. $containerID:/src
-	 exec "$PREBUILD_COMMAND/src/lib/node/build.sh"
-	 exec "cd /src && npm rebuild"
-	 exec "cd /src && npm test"
-	 docker cp $containerID:/src/lib/node/out/Release/node ../build/$PACKAGE_VERSION/$BINARY_NAME
-	 ;;
+		docker cp ../. $containerID:/src
+		exec "$PREBUILD_COMMAND/src/lib/node/build.sh"
+		exec "cd /src && npm rebuild"
+		exec "cd /src && npm test"
+		docker cp $containerID:/src/lib/node/out/Release/node ../build/$PACKAGE_VERSION/$BINARY_NAME
+		;;
 	*)
-	 containerID=$(docker create -it -v $HOME/$CACHE_DIR:/ccache $IMAGE)
-	 docker start $containerID
-	 docker exec $containerID mkdir /src
+	containerID=$(docker create -it -v $HOME/$CACHE_DIR:/ccache $IMAGE)
+	docker start $containerID
+	docker exec $containerID mkdir /src
 
-	 function exec() {
-	 	 docker exec $containerID bash -c "$@"
-	 }
+	function exec() {
+		docker exec $containerID bash -c "$@"
+	}
 
-	 docker cp ../. $containerID:/src
-	 exec "$PREBUILD_COMMAND/src/lib/node/build.sh"
-	 exec "cd /src && npm rebuild"
-	 exec "cd /src && npm test"
-	 docker cp $containerID:/src/lib/node/out/Release/node ../build/$PACKAGE_VERSION/$BINARY_NAME
-	;;
-    esac
+		docker cp ../. $containerID:/src
+		exec "$PREBUILD_COMMAND/src/lib/node/build.sh"
+		exec "cd /src && npm rebuild"
+		exec "cd /src && npm test"
+		docker cp $containerID:/src/lib/node/out/Release/node ../build/$PACKAGE_VERSION/$BINARY_NAME
+		;;
+	esac
 }
 
 if [[ "$TARGET" == "alpine" ]]; then


### PR DESCRIPTION
This might have a few conflicts which I'll be fixing shortly.


This adds ARM support for `nbin`, which should allow cdr/code-server#35 to be possible.

Do not merge this until I have created a helper PR so it won't break infra within code-server.