### PR TITLE
scripts: fix node build script being hardcoded to x86

### DIFF
--- a/scripts/node_build.bash
+++ b/scripts/node_build.bash
@@ -3,21 +3,6 @@
 
 set -Eeuo pipefail
 
-ARCH=
-case "$(uname -m)" in
-   x86_64)
-     ARCH="x64"
-     ;;
-   aarch64)
-     ARCH="arm64"
-     ;;
-    armv7l)
-     ARCH="armv7"
-     ;;
-    *)
-     echo "Unsupported arch!" && exit 3
-     ;;
-esac
 
 function main() {
   cd "$(dirname "$0")/../lib/node"
@@ -48,7 +33,6 @@ function main() {
   echo "cores: $cores"
 
   ./configure \
-    --dest-cpu="$ARCH" \
     --link-module ./lib/nbin.js \
     --link-module ./lib/_third_party_main.js \
     --openssl-no-asm --openssl-use-def-ca-store

--- a/scripts/node_build.bash
+++ b/scripts/node_build.bash
@@ -3,6 +3,22 @@
 
 set -Eeuo pipefail
 
+ARCH=
+case "$(uname -m)" in
+   x86_64)
+     ARCH="x64"
+     ;;
+   aarch64)
+     ARCH="arm64"
+     ;;
+    armv7l)
+     ARCH="armv7"
+     ;;
+    *)
+     echo "Unsupported arch!" && exit 3
+     ;;
+esac
+
 function main() {
   cd "$(dirname "$0")/../lib/node"
 
@@ -32,7 +48,7 @@ function main() {
   echo "cores: $cores"
 
   ./configure \
-    --dest-cpu=x64 \
+    --dest-cpu="$ARCH" \
     --link-module ./lib/nbin.js \
     --link-module ./lib/_third_party_main.js \
     --openssl-no-asm --openssl-use-def-ca-store


### PR DESCRIPTION
This will allow us to run ARM builds now.