### PR TITLE
Drone CI Migration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,12 +10,32 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-amd64
+    path: /root/.cache/ccache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+
+- name: rebuild-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-amd64
+    path: /root/.cache/ccache
+  settings:
+    rebuild: true
+    mount:
+      - /root/.cache/ccache
 
 ---
 ## ARM64 - Master Build Test
@@ -28,12 +48,32 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-arm64
+    path: /root/.cache/ccache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+
+- name: rebuild-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-arm64
+    path: /root/.cache/ccache
+  settings:
+    rebuild: true
+    mount:
+      - /root/.cache/ccache
 
 ---
 ## ARM - Master Build Test
@@ -46,12 +86,32 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-arm
+    path: /root/.cache/ccache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+
+- name: rebuild-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-arm
+    path: /root/.cache/ccache
+  settings:
+    rebuild: true
+    mount:
+      - /root/.cache/ccache
 
 ---
 ## AMD64 - Release
@@ -63,6 +123,16 @@ platform:
   arch: amd64
 
 steps:
+
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-amd64
+    path: /root/.cache/ccache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
 
 - name: build
   image: node:10
@@ -96,6 +166,16 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-arm64
+    path: /root/.cache/ccache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
@@ -127,6 +207,16 @@ platform:
   arch: arm
 
 steps:
+
+- name: restore-cache
+  image: drillster/drone-volume-cache
+  volumes:
+  - name: ccache-arm
+    path: /root/.cache/ccache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
 
 - name: build
   image: node:10

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ platform:
 steps:
 
 - name: build
-  image: ubuntu
+  image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -29,7 +29,7 @@ platform:
 steps:
 
 - name: build
-  image: ubuntu
+  image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -47,7 +47,7 @@ platform:
 steps:
 
 - name: build
-  image: ubuntu
+  image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -65,7 +65,7 @@ platform:
 steps:
 
 - name: build
-  image: ubuntu
+  image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -97,7 +97,7 @@ platform:
 steps:
 
 - name: build
-  image: ubuntu
+  image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -129,7 +129,7 @@ platform:
 steps:
 
 - name: build
-  image: ubuntu
+  image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ platform:
 steps:
 
 - name: restore-cache
-  image: drillster/drone-volume-cache
+  image: chinodesuuu/drone-volume-cache:amd64
   volumes:
   - name: ccache-amd64
     path: /cache
@@ -26,9 +26,10 @@ steps:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+    - yarn test
 
 - name: rebuild-cache
-  image: drillster/drone-volume-cache
+  image: chinodesuuu/drone-volume-cache:amd64
   volumes:
   - name: ccache-amd64
     path: /cache
@@ -49,7 +50,7 @@ platform:
 steps:
 
 - name: restore-cache
-  image: chinodesuuu/drone-volume-cache
+  image: chinodesuuu/drone-volume-cache:arm64
   volumes:
   - name: ccache-arm64
     path: /cache
@@ -64,9 +65,10 @@ steps:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+    - yarn test
 
 - name: rebuild-cache
-  image: chinodesuuu/drone-volume-cache
+  image: chinodesuuu/drone-volume-cache:arm64
   volumes:
   - name: ccache-arm64
     path: /cache
@@ -87,7 +89,7 @@ platform:
 steps:
 
 - name: restore-cache
-  image: chinodesuuu/drone-volume-cache
+  image: chinodesuuu/drone-volume-cache:arm
   volumes:
   - name: ccache-arm
     path: /cache
@@ -102,9 +104,10 @@ steps:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+    - yarn test
 
 - name: rebuild-cache
-  image: chinodesuuu/drone-volume-cache
+  image: chinodesuuu/drone-volume-cache:arm
   volumes:
   - name: ccache-arm
     path: /cache
@@ -125,12 +128,23 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: chinodesuuu/drone-volume-cache:amd64
+  volumes:
+  - name: ccache-amd64
+    path: /cache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+    - yarn test
 
 - name: deploy
   image: plugins/gcs
@@ -157,12 +171,23 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: chinodesuuu/drone-volume-cache:arm64
+  volumes:
+  - name: ccache-arm64
+    path: /cache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+    - yarn test
 
 - name: deploy
   image: plugins/gcs
@@ -189,12 +214,23 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: chinodesuuu/drone-volume-cache:arm
+  volumes:
+  - name: ccache-arm
+    path: /cache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+    - yarn test
 
 - name: deploy
   image: plugins/gcs

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   image: drillster/drone-volume-cache
   volumes:
   - name: ccache-amd64
-    path: /root/.cache/ccache
+    path: /cache
   settings:
     restore: true
     mount:
@@ -31,7 +31,7 @@ steps:
   image: drillster/drone-volume-cache
   volumes:
   - name: ccache-amd64
-    path: /root/.cache/ccache
+    path: /cache
   settings:
     rebuild: true
     mount:
@@ -48,12 +48,32 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: chinodesuuu/drone-volume-cache
+  volumes:
+  - name: ccache-arm64
+    path: /cache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+
+- name: rebuild-cache
+  image: chinodesuuu/drone-volume-cache
+  volumes:
+  - name: ccache-arm64
+    path: /cache
+  settings:
+    rebuild: true
+    mount:
+      - /root/.cache/ccache
 
 ---
 ## ARM - Master Build Test
@@ -66,12 +86,33 @@ platform:
 
 steps:
 
+- name: restore-cache
+  image: chinodesuuu/drone-volume-cache
+  volumes:
+  - name: ccache-arm
+    path: /cache
+  settings:
+    restore: true
+    mount:
+      - /root/.cache/ccache
+
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
+
+- name: rebuild-cache
+  image: chinodesuuu/drone-volume-cache
+  volumes:
+  - name: ccache-arm
+    path: /cache
+  settings:
+    rebuild: true
+    mount:
+      - /root/.cache/ccache
+
 
 ---
 ## AMD64 - Release

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,144 @@
+# Drone CI Pipeline for nbin
+
+## AMD64 Pipeline - Master Build Test
+kind: pipeline
+type: docker
+
+platform:
+  arch: amd64
+
+stpes:
+
+- name: build
+  image: ubuntu
+  commands:
+    - sudo apt update && sudo apt install -y build-essential ccache
+    - yarn
+    - yarn build
+
+---
+## ARM64 - Master Build Test
+kind: pipeline
+type: docker
+
+platform:
+  arch: arm64
+
+stpes:
+
+- name: build
+  image: ubuntu
+  commands:
+    - sudo apt update && sudo apt install -y build-essential ccache
+    - yarn
+    - yarn build
+
+---
+## ARM - Master Build Test
+kind: pipeline
+type: docker
+
+platform:
+  arch: arm
+
+stpes:
+
+- name: build
+  image: ubuntu
+  commands:
+    - sudo apt update && sudo apt install -y build-essential ccache
+    - yarn
+    - yarn build
+
+---
+## AMD64 - Release
+kind: pipeline
+type: docker
+
+platform:
+  arch: amd64
+
+stpes:
+
+- name: build
+  image: ubuntu
+  commands:
+    - sudo apt update && sudo apt install -y build-essential ccache
+    - yarn
+    - yarn build
+
+- name: deploy
+  image: plugins/gcs
+  settings:
+     source: build/
+     target: nbin.cdr.sh
+     token:
+       from_secret: gcs-token
+
+trigger:
+  branch:
+  - master
+  event:
+  - tag
+
+---
+## ARM64 - Release
+kind: pipeline
+type: docker
+
+platform:
+  arch: arm64
+
+stpes:
+
+- name: build
+  image: ubuntu
+  commands:
+    - sudo apt update && sudo apt install -y build-essential ccache
+    - yarn
+    - yarn build
+
+- name: deploy
+  image: plugins/gcs
+  settings:
+     source: build/
+     target: nbin.cdr.sh
+     token:
+       from_secret: gcs-token
+
+trigger:
+  branch:
+  - master
+  event:
+  - tag
+
+---
+## ARM - Release
+kind: pipeline
+type: docker
+
+platform:
+  arch: arm
+
+stpes:
+
+- name: build
+  image: ubuntu
+  commands:
+    - sudo apt update && sudo apt install -y build-essential ccache
+    - yarn
+    - yarn build
+
+- name: deploy
+  image: plugins/gcs
+  settings:
+     source: build/
+     target: nbin.cdr.sh
+     token:
+       from_secret: gcs-token
+
+trigger:
+  branch:
+  - master
+  event:
+  - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
       - /root/.cache/ccache
 
 - name: build
-  image: node:10
+  image: node:12
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -60,7 +60,7 @@ steps:
       - /root/.cache/ccache
 
 - name: build
-  image: node:10
+  image: node:12
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -99,7 +99,7 @@ steps:
       - /root/.cache/ccache
 
 - name: build
-  image: node:10
+  image: node:12
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -139,7 +139,7 @@ steps:
       - /root/.cache/ccache
 
 - name: build
-  image: node:10
+  image: node:12
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -182,7 +182,7 @@ steps:
       - /root/.cache/ccache
 
 - name: build
-  image: node:10
+  image: node:12
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
@@ -225,7 +225,7 @@ steps:
       - /root/.cache/ccache
 
 - name: build
-  image: node:10
+  image: node:12
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,32 +48,12 @@ platform:
 
 steps:
 
-- name: restore-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-arm64
-    path: /root/.cache/ccache
-  settings:
-    restore: true
-    mount:
-      - /root/.cache/ccache
-
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
-
-- name: rebuild-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-arm64
-    path: /root/.cache/ccache
-  settings:
-    rebuild: true
-    mount:
-      - /root/.cache/ccache
 
 ---
 ## ARM - Master Build Test
@@ -86,32 +66,12 @@ platform:
 
 steps:
 
-- name: restore-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-arm
-    path: /root/.cache/ccache
-  settings:
-    restore: true
-    mount:
-      - /root/.cache/ccache
-
 - name: build
   image: node:10
   commands:
     - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
-
-- name: rebuild-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-arm
-    path: /root/.cache/ccache
-  settings:
-    rebuild: true
-    mount:
-      - /root/.cache/ccache
 
 ---
 ## AMD64 - Release
@@ -123,16 +83,6 @@ platform:
   arch: amd64
 
 steps:
-
-- name: restore-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-amd64
-    path: /root/.cache/ccache
-  settings:
-    restore: true
-    mount:
-      - /root/.cache/ccache
 
 - name: build
   image: node:10
@@ -166,16 +116,6 @@ platform:
 
 steps:
 
-- name: restore-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-arm64
-    path: /root/.cache/ccache
-  settings:
-    restore: true
-    mount:
-      - /root/.cache/ccache
-
 - name: build
   image: node:10
   commands:
@@ -207,16 +147,6 @@ platform:
   arch: arm
 
 steps:
-
-- name: restore-cache
-  image: drillster/drone-volume-cache
-  volumes:
-  - name: ccache-arm
-    path: /root/.cache/ccache
-  settings:
-    restore: true
-    mount:
-      - /root/.cache/ccache
 
 - name: build
   image: node:10

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,11 +3,12 @@
 ## AMD64 Pipeline - Master Build Test
 kind: pipeline
 type: docker
+name: build-master-amd64
 
 platform:
   arch: amd64
 
-stpes:
+steps:
 
 - name: build
   image: ubuntu
@@ -20,11 +21,12 @@ stpes:
 ## ARM64 - Master Build Test
 kind: pipeline
 type: docker
+name: build-master-arm64
 
 platform:
   arch: arm64
 
-stpes:
+steps:
 
 - name: build
   image: ubuntu
@@ -37,11 +39,12 @@ stpes:
 ## ARM - Master Build Test
 kind: pipeline
 type: docker
+name: build-master-arm
 
 platform:
   arch: arm
 
-stpes:
+steps:
 
 - name: build
   image: ubuntu
@@ -54,11 +57,12 @@ stpes:
 ## AMD64 - Release
 kind: pipeline
 type: docker
+name: rel-amd64
 
 platform:
   arch: amd64
 
-stpes:
+steps:
 
 - name: build
   image: ubuntu
@@ -85,11 +89,12 @@ trigger:
 ## ARM64 - Release
 kind: pipeline
 type: docker
+name: rel-arm64
 
 platform:
   arch: arm64
 
-stpes:
+steps:
 
 - name: build
   image: ubuntu
@@ -116,11 +121,12 @@ trigger:
 ## ARM - Release
 kind: pipeline
 type: docker
+name: rel-arm
 
 platform:
   arch: arm
 
-stpes:
+steps:
 
 - name: build
   image: ubuntu

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
 - name: build
   image: ubuntu
   commands:
-    - sudo apt update && sudo apt install -y build-essential ccache
+    - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
 
@@ -31,7 +31,7 @@ steps:
 - name: build
   image: ubuntu
   commands:
-    - sudo apt update && sudo apt install -y build-essential ccache
+    - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
 
@@ -49,7 +49,7 @@ steps:
 - name: build
   image: ubuntu
   commands:
-    - sudo apt update && sudo apt install -y build-essential ccache
+    - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
 
@@ -67,7 +67,7 @@ steps:
 - name: build
   image: ubuntu
   commands:
-    - sudo apt update && sudo apt install -y build-essential ccache
+    - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
 
@@ -99,7 +99,7 @@ steps:
 - name: build
   image: ubuntu
   commands:
-    - sudo apt update && sudo apt install -y build-essential ccache
+    - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
 
@@ -131,7 +131,7 @@ steps:
 - name: build
   image: ubuntu
   commands:
-    - sudo apt update && sudo apt install -y build-essential ccache
+    - apt update && apt install -y build-essential ccache
     - yarn
     - yarn build
 


### PR DESCRIPTION
This migrates `nbin` to Drone CI which allows ARM32 and ARM64 to be built.

Requires #33. 

Closes #34 